### PR TITLE
Adding support for unknown browsers/crawlers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,5 @@ Style/Documentation:
   Enabled: false
 Metrics/BlockLength:
   Max: 30
+  Exclude:
+    - 'spec/*'

--- a/lib/jpg_or_webp.rb
+++ b/lib/jpg_or_webp.rb
@@ -14,6 +14,7 @@ class JpgOrWebp
   end
 
   def image_format
+    return 'jpg' if @browser.unknown?
     return 'jpg' if @browser.ie?
     return 'jpg' if @browser.safari? && @browser.platform.mac?('<11.6')
     return 'jpg' if @browser.platform.ios?('<14')

--- a/spec/jpg_or_webp_spec.rb
+++ b/spec/jpg_or_webp_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe JpgOrWebp do
     expect(j.image_format).to eq('jpg')
   end
 
+  it 'sends JPEGs to the LinkedIn crawler' do
+    j = JpgOrWebp.new(
+      'LinkedInBot/1.0 (compatible; Mozilla/5.0; ' \
+      'Apache-HttpClient +http://www.linkedin.com)'
+    )
+    expect(j.image_format).to eq('jpg')
+  end
+
   it 'assumes a recent version of Chrome prefers WebP' do
     j = JpgOrWebp.new(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' \


### PR DESCRIPTION
Some things only want JPEGs because they are old, clunky and awful like LinkedIn.